### PR TITLE
Removing entity count convenience fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# IntelliJ IDEA editor files
+.idea
+*.iml
+
+# Distribution / packaging
+*.egg-info/
+.eggs/
+
+# Byte-compiled
+*.pyc

--- a/dictionaries/rcsb_mmcif_ext_v1.dic
+++ b/dictionaries/rcsb_mmcif_ext_v1.dic
@@ -3203,44 +3203,4 @@ save__rcsb_entry_info.experimental_method_count
     _item.mandatory_code          no
     _item_type.code               int
      save_
-
-save__rcsb_entry_info.polymer_entity_count
-    _item_description.description
-;  The number of distinct polymer entities in the structure entry.
-;
-    _item.name                  '_rcsb_entry_info.polymer_entity_count'
-    _item.category_id             rcsb_entry_info
-    _item.mandatory_code          no
-    _item_type.code               int
-     save_
-
-save__rcsb_entry_info.nonpolymer_entity_count
-    _item_description.description
-;  The number of distinct non-polymer entities exclusive of solvent in the structure entry.
-;
-    _item.name                  '_rcsb_entry_info.nonpolymer_method_count'
-    _item.category_id             rcsb_entry_info
-    _item.mandatory_code          no
-    _item_type.code               int
-     save_
-
-save__rcsb_entry_info.branched_entity_count
-    _item_description.description
-;  The number of distinct branched entities in the structure entry.
-;
-    _item.name                  '_rcsb_entry_info.branched_method_count'
-    _item.category_id             rcsb_entry_info
-    _item.mandatory_code          no
-    _item_type.code               int
-     save_
-
-save__rcsb_entry_info.entity_count
-    _item_description.description
-;  The number of distinct polymer, non-polymer and branched molecular entities exclusive of solvent in the structure entry.
-;
-    _item.name                  '_rcsb_entry_info.entity_count'
-    _item.category_id             rcsb_entry_info
-    _item.mandatory_code          no
-    _item_type.code               int
-     save_
 #


### PR DESCRIPTION
In this PR I propose to remove convenience fields for entities. Instead, we try first derive this data by  SOLR.

The initial commit includes the definition for the fields.  There are couple of configuration files that use these fields. It's not clear to me weather they are automatically created or curated manually.

@jdwestbrook, if you agree with proposed changes, could you, please, suggest the course of actions? 