### PR TITLE
Fix invalid PDBX_COMP_MODEL_CACHE_LIST_PATH

### DIFF
--- a/config/dbload-setup-example.yml
+++ b/config/dbload-setup-example.yml
@@ -217,7 +217,7 @@ site_info_remote_configuration:
   VRPT_REPO_PATH_ENV: VRPT_REPO_PATH_ALT
   #
   RCSB_EDMAP_LIST_PATH: http://workflow-east.rcsb.org/data/edmaps/edmaps.json
-  PDBX_COMP_MODEL_CACHE_LIST_PATH: http://computed-models-internal-east.rcsb.org/holdings/computed-models-holdings.json.gz
+  PDBX_COMP_MODEL_CACHE_LIST_PATH: http://computed-models-internal-east.rcsb.org/staging/holdings/computed-models-holdings.json.gz
   #
   RCSB_SEQUENCE_CLUSTER_DATA_PATH: /net/users/update/Data/sequence-clusters/current-mmseqs
   SIFTS_SUMMARY_DATA_PATH: http://workflow-east.rcsb.org/data/sifts/pub/databases/msd/sifts/flatfiles/csv


### PR DESCRIPTION
This config setting was pointing to an invalid URI that returns a 404. Update to one that works (assuming on the East network).